### PR TITLE
improvements(cli): Align debug CLI commands with Cosmos SDK plus other minor clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog was created using the `clu` binary
 
 ### Improvements
 
+- (cli) [#54](https://github.com/evmos/os/pull/54) Align debug CLI commands with Cosmos SDK plus other minor clean up.
 - (cli) [#53](https://github.com/evmos/os/pull/53) Enable specifying default key type for adding keys.
 - (ante) [#52](https://github.com/evmos/os/pull/52) Refactor ante handlers to be easier to use in partner chains.
 - (all) [#48](https://github.com/evmos/os/pull/48) Move latest changes from evmOS main (f943af3b incl. SDK v50).

--- a/client/debug/debug.go
+++ b/client/debug/debug.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	cosmosclientdebug "github.com/cosmos/cosmos-sdk/client/debug"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
@@ -35,10 +36,18 @@ func Cmd() *cobra.Command {
 		RunE:  client.ValidateCmd,
 	}
 
-	cmd.AddCommand(PubkeyCmd())
-	cmd.AddCommand(AddrCmd())
-	cmd.AddCommand(RawBytesCmd())
-	cmd.AddCommand(LegacyEIP712Cmd())
+	cmd.AddCommand(
+		// default Cosmos SDK debug commands
+		cosmosclientdebug.CodecCmd(),
+		cosmosclientdebug.PrefixesCmd(),
+		cosmosclientdebug.PubkeyRawCmd(), // TODO: support eth_secp256k1 pubkeys for this one too?
+
+		// evmOS adjusted debug commands
+		PubkeyCmd(),
+		AddrCmd(),
+		RawBytesCmd(),
+		LegacyEIP712Cmd(),
+	)
 
 	return cmd
 }

--- a/client/keys.go
+++ b/client/keys.go
@@ -22,14 +22,12 @@ import (
 //
 // The defaultToEthKeys boolean indicates whether to use
 // Ethereum compatible keys by default or stick with the Cosmos SDK default.
-//
-// TODO: (on follow up PR) adjust Tendermint mentions to CometBFT
 func KeyCommands(defaultNodeHome string, defaultToEthKeys bool) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "keys",
 		Short: "Manage your application's keys",
 		Long: `Keyring management commands. These keys may be in any format supported by the
-Tendermint crypto library and can be used by light-clients, full nodes, or any other application
+CometBFT crypto library and can be used by light-clients, full nodes, or any other application
 that needs to sign with a private key.
 
 The keyring supports the following backends:

--- a/server/util.go
+++ b/server/util.go
@@ -30,13 +30,13 @@ func AddCommands(
 	appExport types.AppExporter,
 	addStartFlags types.ModuleInitFlags,
 ) {
-	// TODO: this needs to be updated to use the comet subcommands and alias it to tendermint
-	tendermintCmd := &cobra.Command{
-		Use:   "tendermint",
-		Short: "Tendermint subcommands",
+	cometbftCmd := &cobra.Command{
+		Use:     "comet",
+		Aliases: []string{"cometbft", "tendermint"},
+		Short:   "CometBFT subcommands",
 	}
 
-	tendermintCmd.AddCommand(
+	cometbftCmd.AddCommand(
 		sdkserver.ShowNodeIDCmd(),
 		sdkserver.ShowValidatorCmd(),
 		sdkserver.ShowAddressCmd(),
@@ -51,7 +51,7 @@ func AddCommands(
 
 	rootCmd.AddCommand(
 		startCmd,
-		tendermintCmd,
+		cometbftCmd,
 		sdkserver.ExportCmd(appExport, opts.DefaultNodeHome),
 		version.NewVersionCommand(),
 		sdkserver.NewRollbackCmd(opts.AppCreator, opts.DefaultNodeHome),

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -101,7 +101,7 @@ func NewRawTxCmd() *cobra.Command {
 				return err
 			}
 
-			// broadcast to a Tendermint node
+			// broadcast to a CometBFT node
 			res, err := clientCtx.BroadcastTx(txBytes)
 			if err != nil {
 				return err

--- a/x/evm/types/codec.go
+++ b/x/evm/types/codec.go
@@ -47,7 +47,7 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 		&MsgUpdateParams{},
 	)
 	registry.RegisterInterface(
-		"ethermint.evm.v1.TxData",
+		"os.evm.v1.TxData",
 		(*TxData)(nil),
 		&DynamicFeeTx{},
 		&AccessListTx{},

--- a/x/evm/types/codec.go
+++ b/x/evm/types/codec.go
@@ -26,7 +26,7 @@ var (
 
 const (
 	// Amino names
-	updateParamsName = "os/MsgUpdateParams"
+	updateParamsName = "os/evm/MsgUpdateParams"
 )
 
 // NOTE: This is required for the GetSignBytes function

--- a/x/evm/types/logs.go
+++ b/x/evm/types/logs.go
@@ -69,7 +69,7 @@ func (log *Log) Validate() error {
 	return nil
 }
 
-// ToEthereum returns the Ethereum type Log from a Ethermint proto compatible Log.
+// ToEthereum returns the Ethereum type Log from an evmOS proto compatible Log.
 func (log *Log) ToEthereum() *ethtypes.Log {
 	topics := make([]common.Hash, len(log.Topics))
 	for i, topic := range log.Topics {
@@ -98,7 +98,7 @@ func NewLogsFromEth(ethlogs []*ethtypes.Log) []*Log {
 	return logs
 }
 
-// LogsToEthereum casts the Ethermint Logs to a slice of Ethereum Logs.
+// LogsToEthereum casts the evmOS logs to a slice of Ethereum Logs.
 func LogsToEthereum(logs []*Log) []*ethtypes.Log {
 	var ethLogs []*ethtypes.Log //nolint: prealloc
 	for i := range logs {


### PR DESCRIPTION
This PR aligns the `appd debug` subcommands with the Cosmos SDK's available subcommands and does some other minor clean up like renaming occurences of Tendermint to CometBFT, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced command-line interface for debugging with new commands.
	- Default key type specification for key addition.
	- Server implementation and new RPC/indexer types introduced.
	- New client, command, and version packages added.

- **Bug Fixes**
	- Improved validation logic for transaction logs.

- **Documentation**
	- Updated changelog with new features and enhancements.
	- Documentation improvements including a new README and example chain implementation.

- **Refactor**
	- Ante handlers refactored for easier integration with partner chains.

- **Chores**
	- CI configuration updates and new compilation scripts added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->