### PR TITLE
imp(cli): Add missing list key types subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog was created using the `clu` binary
 
 ### Improvements
 
+- (cli) [#55](https://github.com/evmos/os/pull/55) Add missing list key types subcommand.
 - (cli) [#54](https://github.com/evmos/os/pull/54) Align debug CLI commands with Cosmos SDK plus other minor clean up.
 - (cli) [#53](https://github.com/evmos/os/pull/53) Enable specifying default key type for adding keys.
 - (ante) [#52](https://github.com/evmos/os/pull/52) Refactor ante handlers to be easier to use in partner chains.

--- a/client/keys.go
+++ b/client/keys.go
@@ -73,6 +73,7 @@ The pass backend requires GnuPG: https://gnupg.org/
 		keys.ExportKeyCommand(),
 		keys.ImportKeyCommand(),
 		keys.ListKeysCmd(),
+		keys.ListKeyTypesCmd(),
 		keys.ShowKeysCmd(),
 		keys.DeleteKeyCommand(),
 		keys.RenameKeyCommand(),


### PR DESCRIPTION
This PR adds the `appd keys list-key-types` command, that was not included in evmOS' `keys` commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new CLI subcommand to list available key types in the keyring.
	- Updated default signing algorithm for key addition to align with Ethereum standards.

- **Improvements**
	- Enhanced debug CLI commands for better alignment with the Cosmos SDK.
	- Integrated changes from the evmOS main branch and added new packages and directories.

- **Chores**
	- Updated the changelog with new entries and improvements.
	- Added CI workflows and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->