### PR TITLE
imp(cli): Use evmOS' flavored debug subcommands in example chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog was created using the `clu` binary
 
 ### Improvements
 
+- (cli) [#58](https://github.com/evmos/os/pull/58) Use evmOS' flavored debug subcommands in example chain.
 - (cli) [#55](https://github.com/evmos/os/pull/55) Add missing list key types subcommand.
 - (cli) [#54](https://github.com/evmos/os/pull/54) Align debug CLI commands with Cosmos SDK plus other minor clean up.
 - (cli) [#53](https://github.com/evmos/os/pull/53) Enable specifying default key type for adding keys.

--- a/example_chain/osd/cmd/root.go
+++ b/example_chain/osd/cmd/root.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	clientcfg "github.com/cosmos/cosmos-sdk/client/config"
-	"github.com/cosmos/cosmos-sdk/client/debug"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/pruning"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
@@ -37,6 +36,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	evmoscmd "github.com/evmos/os/client"
+	evmosdebug "github.com/evmos/os/client/debug"
 	evmoscmdconfig "github.com/evmos/os/cmd/config"
 	evmoskeyring "github.com/evmos/os/crypto/keyring"
 	"github.com/evmos/os/example_chain"
@@ -207,6 +207,7 @@ func initRootCmd(rootCmd *cobra.Command, osApp *example_chain.ExampleChain) {
 	cfg := sdk.GetConfig()
 	cfg.Seal()
 
+	// add Cosmos native CLI commands
 	rootCmd.AddCommand(
 		genutilcli.InitCmd(
 			osApp.BasicModuleManager,
@@ -214,7 +215,6 @@ func initRootCmd(rootCmd *cobra.Command, osApp *example_chain.ExampleChain) {
 		),
 		genutilcli.Commands(osApp.TxConfig(), osApp.BasicModuleManager, example_chain.DefaultNodeHome),
 		cmtcli.NewCompletionCmd(rootCmd, true),
-		debug.Cmd(),
 		confixcmd.ConfigCommand(),
 		pruning.Cmd(newApp, example_chain.DefaultNodeHome),
 		snapshot.Cmd(newApp),
@@ -232,6 +232,9 @@ func initRootCmd(rootCmd *cobra.Command, osApp *example_chain.ExampleChain) {
 	rootCmd.AddCommand(
 		evmoscmd.KeyCommands(example_chain.DefaultNodeHome, true),
 	)
+
+	// add evmOS' flavored debug command
+	rootCmd.AddCommand(evmosdebug.Cmd())
 
 	// add keybase, auxiliary RPC, query, genesis, and tx child commands
 	rootCmd.AddCommand(


### PR DESCRIPTION
This PR wires the example chain implementation in the repo to use the evmOS' extended `debug` subcommands, that e.g. enable parsing hex addresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced flavored debug subcommands and a list key types subcommand in the CLI for enhanced debugging.
	- Added a new contracts directory and multiple new packages, expanding project capabilities.
	- Integrated support for EIP-712 to improve functionality.

- **Improvements**
	- Updated documentation with a new README and example chain implementations.
	- Enhanced transaction signing capabilities within the application.

- **Tests**
	- Added new tests for Solidity and Ledger to ensure robustness.

- **Chores**
	- Established new CI workflows and configurations for better project management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->